### PR TITLE
Store the generated-data directory onto host

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,3 +10,4 @@ services:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
     volumes:
       - ./html/generated:/app/html/generated
+      - ./generated-data:/app/generated-data


### PR DESCRIPTION
If the generated-data is not persisted, it will be
lost when the container exits. This is required when
the tool is run through the docker compose file.

Signed-off-by: S m, Aruna <arun.s.m.cse@gmail.com>