### PR TITLE
Renamed hyperledger-updated to github-updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-*	@hyperledger-tooling/hyperledger-updates-maintainers
+*	@hyperledger-tooling/github-updates-maintainers

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ COPY . /app
 RUN make
 
 WORKDIR /appbin
-RUN cp /app/hyperledger-updates /appbin/
+RUN cp /app/github-updates /appbin/
 RUN rm -r /app
 
 ENV PATH=${PATH}:/appbin
 
-CMD ["hyperledger-updates"]
+CMD ["github-updates"]

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ format_output=$(shell gofmt -l .)
 all: clean build
 
 clean:
-	rm -f hyperledger-updates
+	rm -f github-updates
 
 build: lint-check unit-test
-	go build -o hyperledger-updates $(LDFLAGS) ./cmd
+	go build -o github-updates $(LDFLAGS) ./cmd
 
 unit-test:
 	CGO_ENABLED=0 go test -v ./...

--- a/README.md
+++ b/README.md
@@ -146,5 +146,5 @@ You may optionally build and run the tool as
 
 ```bash
 make
-./hyperledger-updates
+./github-updates
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,10 +17,10 @@
 package main
 
 import (
+	client2 "github-updates/internal/pkg/client"
+	"github-updates/internal/pkg/configs"
+	"github-updates/internal/pkg/utils"
 	"github.com/google/go-github/v33/github"
-	client2 "hyperledger-updates/internal/pkg/client"
-	"hyperledger-updates/internal/pkg/configs"
-	"hyperledger-updates/internal/pkg/utils"
 	"log"
 	"os"
 	"path"
@@ -30,7 +30,7 @@ import (
 
 var AppVersion = ""
 
-const AppName = "Hyperledger Updates"
+const AppName = "GitHub Updates"
 
 func init() {
 	if AppVersion == "" {

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -15,11 +15,11 @@
 version: "3.6"
 
 services:
-  hyperledger-updates:
+  github-updates:
     build:
       context: ..
       dockerfile: Dockerfile
-    container_name: hyperledger-updates
+    container_name: github-updates
     environment:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       - CONFIG_FILE=/appbin/config.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module hyperledger-updates
+module github-updates
 
 go 1.15
 

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -16,7 +16,7 @@
 
 package client
 
-import "hyperledger-updates/internal/pkg/configs"
+import "github-updates/internal/pkg/configs"
 
 // GHClientInterface is for testing
 type GHClientInterface interface {

--- a/internal/pkg/client/ghclient.go
+++ b/internal/pkg/client/ghclient.go
@@ -19,8 +19,8 @@ package client
 import (
 	ctx "context"
 	"errors"
-	"hyperledger-updates/internal/pkg/configs"
-	"hyperledger-updates/internal/pkg/utils"
+	"github-updates/internal/pkg/configs"
+	"github-updates/internal/pkg/utils"
 	"log"
 	"net/http"
 	"time"

--- a/internal/pkg/configs/configuration.go
+++ b/internal/pkg/configs/configuration.go
@@ -17,8 +17,8 @@
 package configs
 
 import (
+	"github-updates/internal/pkg/utils"
 	"gopkg.in/yaml.v2"
-	"hyperledger-updates/internal/pkg/utils"
 	"io/ioutil"
 	"log"
 )


### PR DESCRIPTION
This tooling is not unique to hyperledger, thus renaming it to github-updates.