### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-*	@hyperledger-tooling/hyperledger-updates-maintainers
+*	@hyperledger-tooling/github-updates-maintainers


### PR DESCRIPTION
Updating Code Owners, since we decided to update the repository from hyperledger-updates to github-updates.