### PR TITLE
Add option to pull contributor data

### DIFF
--- a/assets/config.yaml
+++ b/assets/config.yaml
@@ -33,9 +33,9 @@ issues:
     - "good first issue"
     - "help wanted"
   created-history-days: 100
-  summary-filename: "html/generated/issue-summary.html"
+  summary-filename: "assets/html/generated/issue-summary.html"
   should-run: true
-  data-file: "generated-data/issue-data.json"
+  data-file: "assets/generated-data/issue-data.json"
   external-template:
     input: ""
     output: ""
@@ -44,9 +44,9 @@ issues:
 
 # Config for Pull Requests
 pull-requests:
-  summary-filename: "html/generated/pr-summary.html"
+  summary-filename: "assets/html/generated/pr-summary.html"
   should-run: true
-  data-file: "generated-data/pr-data.json"
+  data-file: "assets/generated-data/pr-data.json"
   external-template:
     input: ""
     output: ""
@@ -55,9 +55,20 @@ pull-requests:
 
 # Config for Releases
 releases:
-  summary-filename: "html/generated/release-summary.html"
+  summary-filename: "assets/html/generated/release-summary.html"
   should-run: true
-  data-file: "generated-data/release-data.json"
+  data-file: "assets/generated-data/release-data.json"
+  external-template:
+    input: ""
+    output: ""
+    summary: ""
+    sum-generated: ""
+
+# Config for Contributors
+contributors:
+  summary-filename: "assets/html/generated/contributor-summary.html"
+  should-run: true
+  data-file: "assets/generated-data/contributor-data.json"
   external-template:
     input: ""
     output: ""

--- a/assets/html/template/contributor-template.html
+++ b/assets/html/template/contributor-template.html
@@ -1,0 +1,55 @@
+<ul class="list-style-none"> {{range .}} </ul>
+<!--Copyright 2021 Hyperledger Community-->
+
+<!--Licensed under the Apache License, Version 2.0 (the "License");-->
+<!--you may not use this file except in compliance with the License.-->
+<!--You may obtain a copy of the License at-->
+
+<!--    http://www.apache.org/licenses/LICENSE-2.0-->
+
+<!--Unless required by applicable law or agreed to in writing, software-->
+<!--distributed under the License is distributed on an "AS IS" BASIS,-->
+<!--WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.-->
+<!--See the License for the specific language governing permissions and-->
+<!--limitations under the License.-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>Contributors</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <link rel='stylesheet' type='text/css' media='screen' href='../css/main.css'>
+</head>
+
+<body>
+    <div class="content">
+        <div class="header">
+            <h2>
+                Here are the contributors to Hyperledger Projects
+            </h2>
+        </div>
+        <ol class="org">
+            <li style="font-size: 40px">{{.Organization}}</li>
+            <ol class="repo">
+                {{range .ContributorLists}}
+                <ol class="pr-list">
+                    {{range .Contributors}}
+                    <li class="d-inline-block mr-1">
+                        <a href="{{.HTMLURL}}">
+                            <img src="{{.AvatarURL}}" width="32" height="32" alt="{{.ID}}">
+                        </a>
+                    </li> {{end}}
+                    <br />
+                    {{end}}
+                </ol>
+                {{end}}
+            </ol>
+        </ol>
+    </div>
+</body>
+
+</html>
+

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       - PR_TEMPLATE_FILE=/appbin/html/template/pr-template.html
       - RELEASE_TEMPLATE_FILE=/appbin/html/template/release-template.html
       - ISSUE_TEMPLATE_FILE=/appbin/html/template/issue-template.html
+      - CONTRIBUTOR_TEMPLATE_FILE=/appbin/html/template/contributor-template.html
     volumes:
       - ../assets/html:/appbin/html
       - ../assets/generated-data:/appbin/generated-data

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -24,4 +24,5 @@ type GHClientInterface interface {
 	ListPRs(string, []string, int) ([]configs.PrList, error)
 	ListReleases(string, []string, int) ([]configs.ReleaseList, error)
 	IssueWithLabels(string, []string, []string, int) ([]configs.IssueList, error)
+	ListContributors(string, []string) ([]configs.ContributorList, error)
 }

--- a/internal/pkg/configs/configuration.go
+++ b/internal/pkg/configs/configuration.go
@@ -18,10 +18,9 @@ package configs
 
 import (
 	"github-updates/internal/pkg/utils"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
-
-	"gopkg.in/yaml.v2"
 )
 
 // Configuration reads the input config file
@@ -30,6 +29,7 @@ type Configuration struct {
 	Issues              IssueConfiguration       `yaml:"issues"`
 	PullRequests        PullRequestConfiguration `yaml:"pull-requests"`
 	Releases            ReleaseConfiguration     `yaml:"releases"`
+	Contributors        ContributorConfiguration `yaml:"contributors"`
 }
 
 type IssueConfiguration struct {
@@ -53,6 +53,13 @@ type ReleaseConfiguration struct {
 	ReleaseReportShouldRun  bool                    `yaml:"should-run"`
 	ReleaseDataFile         string                  `yaml:"data-file"`
 	ReleaseExternalTemplate ElementExternalTemplate `yaml:"external-template"`
+}
+
+type ContributorConfiguration struct {
+	ContributorSummaryFileName  string                  `yaml:"summary-filename"`
+	ContributorReportShouldRun  bool                    `yaml:"should-run"`
+	ContributorDataFile         string                  `yaml:"data-file"`
+	ContributorExternalTemplate ElementExternalTemplate `yaml:"external-template"`
 }
 
 type ElementExternalTemplate struct {

--- a/internal/pkg/configs/constants.go
+++ b/internal/pkg/configs/constants.go
@@ -27,10 +27,14 @@ const (
 	ReleaseSummaryFilePath = "RELEASE_SUMMARY_FILE_PATH"
 	// IssueSummaryFilePath env variable
 	IssueSummaryFilePath = "ISSUE_SUMMARY_FILE_PATH"
+	// ContributorSummaryFilePath env variable
+	ContributorSummaryFilePath = "CONTRIBUTOR_SUMMARY_FILE_PATH"
 	// PRTemplateFile env variable
 	PRTemplateFile = "PR_TEMPLATE_FILE"
 	// ReleaseTemplateFile env variable
 	ReleaseTemplateFile = "RELEASE_TEMPLATE_FILE"
 	// IssueTemplateFile env variable
 	IssueTemplateFile = "ISSUE_TEMPLATE_FILE"
+	// ContributorTemplateFile env variable
+	ContributorTemplateFile = "CONTRIBUTOR_TEMPLATE_FILE"
 )

--- a/internal/pkg/configs/structures.go
+++ b/internal/pkg/configs/structures.go
@@ -43,6 +43,12 @@ type ExternalReleaseDetails struct {
 	Releases     []github.RepositoryRelease
 }
 
+type ExternalContributorDetails struct {
+	Organization OrganizationStructure
+	Repository   RepositoryStructure
+	Contributors []github.Contributor
+}
+
 // PullRequestDetails contains organization name
 // and PrLists
 type PullRequestDetails struct {
@@ -67,6 +73,11 @@ type IssueDetails struct {
 	IssueLists   []IssueList `json:"issueLists,omitempty"`
 }
 
+type ContributorDetails struct {
+	Organization     string            `json:"organization,omitempty"`
+	ContributorLists []ContributorList `json:"contributorLists,omitempty"`
+}
+
 type ReleaseList struct {
 	Repository string                     `json:"repository,omitempty"`
 	Releases   []github.RepositoryRelease `json:"releases,omitempty"`
@@ -76,4 +87,9 @@ type IssueList struct {
 	Repository string         `json:"repository,omitempty"`
 	Labels     []string       `json:"labels,omitempty"`
 	Issues     []github.Issue `json:"issues,omitempty"`
+}
+
+type ContributorList struct {
+	Repository   string               `json:"repository,omitempty"`
+	Contributors []github.Contributor `json:"issues,omitempty"`
 }


### PR DESCRIPTION
Draft PR:

Partially completes the second item on the [TODO list](https://github.com/hyperledger-tooling/start-here-hyperledger/issues/148#issuecomment-871583611).

Functions and configuration added to generate contributor data.

Contributor [template](https://github.com/abhinandanudupa/github-updates/blob/contributor-pull/assets/html/template/contributor-template.html) and [directory](https://github.com/abhinandanudupa/github-updates/blob/contributor-pull/assets/config.yaml#L39) (should I change to the one with out assets?) needs some feedback and ratification.
